### PR TITLE
Support for Cloudflare API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,20 @@ php artisan vendor:publish --tag="cloudflare-cache-config"
 
 Add environment variables to .env file
 
+##### Using global api key:
+
 ```dotenv
 CLOUDFLARE_CACHE_EMAIL=info@example.com #Cloudflare account email address
-CLOUDFLARE_CACHE_KEY=XXXXXXX #Cloudflare API_KEY
+CLOUDFLARE_CACHE_KEY=XXXXXXX #Cloudflare global api key
+CLOUDFLARE_CACHE_IDENTIFIER=XXXXXXX #ZONE_ID
+CLOUDFLARE_DEFAULT_CACHE_TTL=600 #10 minutes
+CLOUDFLARE_CACHE_DEBUG=false
+```
+
+##### Using fine-grained api token:
+
+```dotenv
+CLOUDFLARE_CACHE_API_TOKEN=XXXXXXX
 CLOUDFLARE_CACHE_IDENTIFIER=XXXXXXX #ZONE_ID
 CLOUDFLARE_DEFAULT_CACHE_TTL=600 #10 minutes
 CLOUDFLARE_CACHE_DEBUG=false

--- a/config/cloudflare-cache.php
+++ b/config/cloudflare-cache.php
@@ -18,6 +18,11 @@ return [
     'api_key' => env('CLOUDFLARE_CACHE_KEY'),
 
     /**
+     * Fine-grained api token.
+     */
+    'api_token' => env('CLOUDFLARE_CACHE_API_TOKEN'),
+
+    /**
      * zone_id of your site on cloudflare dashboard.
      */
     'identifier' => env('CLOUDFLARE_CACHE_IDENTIFIER'),

--- a/src/CloudflareCache.php
+++ b/src/CloudflareCache.php
@@ -100,11 +100,14 @@ class CloudflareCache implements CloudflareCacheInterface
             return true;
         }
 
-        if (! config('cloudflare-cache.api_email')
-            || ! config('cloudflare-cache.api_key')
-            || ! config('cloudflare-cache.identifier')
-        ) {
+        if (! config('cloudflare-cache.identifier')) {
             return false;
+        }
+
+        if (! config('cloudflare-cache.api_token')) {
+            if (! config('cloudflare-cache.api_email') || ! config('cloudflare-cache.api_key')) {
+                return false;
+            }
         }
 
         if (config('cloudflare-cache.debug')) {

--- a/src/CloudflareCacheServiceProvider.php
+++ b/src/CloudflareCacheServiceProvider.php
@@ -48,6 +48,7 @@ class CloudflareCacheServiceProvider extends PackageServiceProvider
                 config('cloudflare-cache.api_email'),
                 config('cloudflare-cache.api_key'),
                 config('cloudflare-cache.identifier'),
+                config('cloudflare-cache.api_token'),
             );
         });
 

--- a/src/Services/CloudflareService.php
+++ b/src/Services/CloudflareService.php
@@ -15,6 +15,7 @@ class CloudflareService implements CloudflareServiceInterface
         private readonly ?string $apiEmail,
         private readonly ?string $apiKey,
         private readonly ?string $identifier,
+        private readonly ?string $apiToken,
     ) {
         // .
     }
@@ -22,10 +23,10 @@ class CloudflareService implements CloudflareServiceInterface
     private function request(): PendingRequest
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
-        return $this->client->withHeaders([
-            'X-Auth-Email' => $this->apiEmail,
-            'X-Auth-Key' => $this->apiKey,
-        ]);
+        return $this->client->withHeaders($this->apiToken
+            ? ['Authorization' => 'Bearer ' . $this->apiToken]
+            : ['X-Auth-Email' => $this->apiEmail, 'X-Auth-Key' => $this->apiKey]
+        );
     }
 
     protected function getBaseUrl(string $endpoint): string


### PR DESCRIPTION
Cloudflare has fine-grained permission based "API Tokens" which they recommend using instead of the "Global API Key" currently used by this package. This PR includes support for it.