### PR TITLE
Set cache tag header only if exist

### DIFF
--- a/src/Mixins/CloudflareRouterMixin.php
+++ b/src/Mixins/CloudflareRouterMixin.php
@@ -50,8 +50,9 @@ class CloudflareRouterMixin
             $tags = Arr::where(Arr::wrap($tags), static fn ($tag) => is_string($tag) && filled($tag));
 
             $request = request();
-            $currentTags = $request->attributes->get(CloudflareCache::TAGS_ATTR, []);
-            $request->attributes->set(CloudflareCache::TAGS_ATTR, array_merge($currentTags, $tags));
+            if ($currentTags = $request->attributes->get(CloudflareCache::TAGS_ATTR)) {
+                $request->attributes->set(CloudflareCache::TAGS_ATTR, array_merge($currentTags, $tags));
+            }
             $registerTtl($ttl, $request);
 
             return $routeRegistrar();


### PR DESCRIPTION
`Cache-Tags` header was appending even when no cache tags specified. This PR fixes it.

Now, the header only gets added if any cache tags are specified.